### PR TITLE
Fixed the access control of RSSFeed and RSSItem variables

### DIFF
--- a/AlamofireRSS.podspec
+++ b/AlamofireRSS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "AlamofireRSS"
-  s.version          = "0.3.0"
+  s.version          = "0.3.1"
   s.summary          = "An RSS parser plugin for Alamofire."
 
 # This description is used to generate tags and improve search results.

--- a/Pod/Classes/RSSFeed.swift
+++ b/Pod/Classes/RSSFeed.swift
@@ -9,20 +9,20 @@
 import Foundation
 
 public class RSSFeed: CustomStringConvertible {
-    var title: String? = nil
-    var link: String? = nil
-    var feedDescription: String? = nil
-    var pubDate: NSDate? = nil
-    var lastBuildDate: NSDate? = nil
-    var language: String? = nil
-    var copyright: String? = nil
-    var managingEditor: String? = nil
-    var webMaster: String? = nil
-    var generator: String? = nil
-    var docs: String? = nil
-    var ttl: NSNumber? = nil
+    public var title: String? = nil
+    public var link: String? = nil
+    public var feedDescription: String? = nil
+    public var pubDate: NSDate? = nil
+    public var lastBuildDate: NSDate? = nil
+    public var language: String? = nil
+    public var copyright: String? = nil
+    public var managingEditor: String? = nil
+    public var webMaster: String? = nil
+    public var generator: String? = nil
+    public var docs: String? = nil
+    public var ttl: NSNumber? = nil
     
-    var items: [RSSItem] = Array()
+    public var items: [RSSItem] = Array()
     
     public var description: String {
         return "title: \(self.title)\nfeedDescription: \(self.feedDescription)\nlink: \(self.link)\npubDate: \(self.pubDate)\nlastBuildDate: \(self.lastBuildDate)\nlanguage: \(self.language)\ncopyright: \(self.copyright)\nmanagingEditor: \(self.managingEditor)\nwebMaster: \(self.webMaster)\ngenerator: \(self.generator)\ndocs: \(self.docs)\nttl: \(self.ttl)\n\titems: \(self.items)"

--- a/Pod/Classes/RSSItem.swift
+++ b/Pod/Classes/RSSItem.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 public class RSSItem: CustomStringConvertible {
-    var title: String? = nil
-    var link: String? = nil
-    var itemDescription: String? = nil
-    var guid: String? = nil
-    var author: String? = nil
-    var comments: String? = nil
-    var source: String? = nil
-    var pubDate: NSDate? = nil
+    public var title: String? = nil
+    public var link: String? = nil
+    public var itemDescription: String? = nil
+    public var guid: String? = nil
+    public var author: String? = nil
+    public var comments: String? = nil
+    public var source: String? = nil
+    public var pubDate: NSDate? = nil
 
     public var description: String {
         return "title: \(self.title)\nlink: \(self.link)\nitemDescription: \(self.itemDescription)\nguid: \(self.guid)\nauthor: \(self.author)\ncomments: \(self.comments)\nsource: \(self.source)\npubDate: \(self.pubDate)"


### PR DESCRIPTION
Until now, most instance variables of `RSSFeed` and `RSSItem` wouldn't be accessible from an app's target since they were internal. I've fixed this by making them `public`.  

Some variables of `AlamofireRSSParser` are still internal, but I think that's on purpose, so I haven't touched this class.